### PR TITLE
Add CapsLock double tap to activate and use {blind} for IJKL

### DIFF
--- a/CapsLockHero.ahk
+++ b/CapsLockHero.ahk
@@ -15,7 +15,7 @@ CapsLock::
 return
 
 ;===============================================================================================
-; Bind jkli to left, down, right
+; Bind jkli to left, down, right, up
 ;===============================================================================================
 CapsLock & J::Send, {blind}{Left}
 CapsLock & K::Send, {blind}{Down}

--- a/CapsLockHero.ahk
+++ b/CapsLockHero.ahk
@@ -1,21 +1,26 @@
 #Persistent
 #SingleInstance force
 
-CapsLock & J::
-	Send, {Left down}
+;================================================================================================
+;  CapsLock processing.  Must double tap CapsLock to toggle CapsLock mode on or off.
+;================================================================================================
+; Must double tap CapsLock to toggle CapsLock mode on or off.
+CapsLock::
+    KeyWait, CapsLock                                                   ; Wait forever until Capslock is released.
+    KeyWait, CapsLock, D T0.2                                           ; ErrorLevel = 1 if CapsLock not down within 0.2 seconds.
+    if ((ErrorLevel = 0) && (A_PriorKey = "CapsLock") )                 ; Is a double tap on CapsLock?
+        {
+        SetCapsLockState, % GetKeyState("CapsLock","T") ? "Off" : "On"  ; Toggle the state of CapsLock LED
+        }
 return
 
-CapsLock & K::
-    Send, {Down down}
-return
-
-CapsLock & L::
-    Send, {Right down}
-return
-
-CapsLock & I::
-    Send, {Up down}
-return
+;===============================================================================================
+; Bind jkli to left, down, right
+;===============================================================================================
+CapsLock & J::Send, {blind}{Left}
+CapsLock & K::Send, {blind}{Down}
+CapsLock & L::Send, {blind}{Right}
+CapsLock & I::Send, {blind}{Up}
 	
 	
 ; Mouse Control


### PR DESCRIPTION
* This will allow the use of CAPS LOCK only if it is tapped twice!
* By using `Blind` for IJKL + CapsLock it allows any other modifiers to still take effect. So now you can hold Shift + CapsLock + IJKL and it will highlight the selected text.

Big shoutout to [GeorgeSeeger](https://github.com/GeorgeSeeger/MyAutohotkeyScripts) for his [ AutoHotkey Scripts](https://github.com/GeorgeSeeger/MyAutohotkeyScripts) from which I ripped all of the code I added. 